### PR TITLE
Fix origin point for sprites

### DIFF
--- a/addons/sparrowatlas_editor/index.gd
+++ b/addons/sparrowatlas_editor/index.gd
@@ -56,8 +56,9 @@ func Notification(what,data):
 				if animation.size()>0:
 					frame=animation[objects["animIndex"].value];
 					
-				var spriteCrop=Rect2(int(frame.x),int(frame.y),int(frame.width),int(frame.height));
+				var spriteCrop=Rect2(int(frame.x),int(frame.y),int(frame.frameWidth),int(frame.frameHeight));
 				var obj=objects["target"];
+
 				if obj!=null:
 					obj.texture=sprite;
 					obj.region_enabled=true;
@@ -202,7 +203,7 @@ func OnIndexChanged(val):
 			objects["titleFrames"].text=str(val,"/",sheet.size()-1)
 	
 func ConvertXML(path):
-	var entries:=["name","width","height","frameX","frameY","x","y"];
+	var entries:=["name","width","height","frameX","frameY","frameWidth","frameHeight","x","y"];
 	var file=XMLParser.new();
 	var result=[];
 	file.open(path);


### PR DESCRIPTION
Felt like fixing this, as I looked into SparrowAtlas things, saw the original and then the GD4 port - now the spritesheets frameWidth and frameHeight get used, causing it to actually position correctly (as seen in this video).

Don't know if this project actually takes pull requests but even if it doesn't, this'll be here for the people who do use it 👍
https://github.com/Lyxilytical/godot-sparrowatlas-editor-GD4PORT/assets/38793386/b4e361e3-50fe-42db-ad04-74e4c0b7202f

